### PR TITLE
get the cluster name from an env var in `aws-secrets-run-in-env`

### DIFF
--- a/bin/aws-secrets-run-in-env
+++ b/bin/aws-secrets-run-in-env
@@ -1,9 +1,7 @@
 #!/bin/sh
 
-cluster=$1
-app=$2
-shift 2
+app=$1
 
-export `aws-secrets-get $cluster $app`
+export `aws-secrets-get $AWS_SECRETS_CLUSTER $app`
 
 exec "$@"


### PR DESCRIPTION
You can't use a variable in the `CMD` in the Dockerfile, so lets pass that info in a build-var that's passed in to the container environment 