### PR TITLE
Use built in env var for cluster

### DIFF
--- a/bin/aws-secrets-run-in-env
+++ b/bin/aws-secrets-run-in-env
@@ -3,9 +3,9 @@
 app=$1
 shift
 
-if [ -n "$AWS_SECRETS_CLUSTER" ]
+if [ -n "$ECS_CLUSTER" ]
 then
-    export `aws-secrets-get $AWS_SECRETS_CLUSTER $app`
+    export `aws-secrets-get $ECS_CLUSTER $app`
 fi
 
 exec "$@"


### PR DESCRIPTION
http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html

The cluster that the ECS container is in is already available as an `env` var so we can use that instead of having to add a new one.